### PR TITLE
fix(docs): replace npm with pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,26 +67,26 @@ That's it! You can now use `nuxt-open-fetch` in your Nuxt app ✨
 
 ```bash
 # Install dependencies
-npm install
+pnpm install
 
 # Generate type stubs
-npm run dev:prepare
+pnpm dev:prepare
 
 # Develop with the playground
-npm run dev
+pnpm dev
 
 # Build the playground
-npm run dev:build
+pnpm dev:build
 
 # Run ESLint
-npm run lint
+pnpm lint
 
 # Run Vitest
-npm run test
-npm run test:watch
+pnpm test
+pnpm test:watch
 
 # Release new version
-npm run release
+pnpm release
 ```
 
 ## License


### PR DESCRIPTION
The README misleads that one must use npm. In fact, the project uses pnpm, and it won't even install with npm:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: @nuxt/test-utils@3.7.4
npm ERR! Found: vitest@0.34.6
npm ERR! node_modules/vitest
npm ERR!   dev vitest@"^0.34.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peerOptional vitest@"^0.30.0 || ^0.31.0 || ^0.32.0 || ^0.33.0" from @nuxt/test-utils@3.7.4
npm ERR! node_modules/@nuxt/test-utils
npm ERR!   dev @nuxt/test-utils@"^3.7.0" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: vitest@0.33.0
npm ERR! node_modules/vitest
npm ERR!   peerOptional vitest@"^0.30.0 || ^0.31.0 || ^0.32.0 || ^0.33.0" from @nuxt/test-utils@3.7.4
npm ERR!   node_modules/@nuxt/test-utils
npm ERR!     dev @nuxt/test-utils@"^3.7.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```