### PR TITLE
fix: add optional operator on createOpenFetch opts

### DIFF
--- a/src/runtime/fetch.ts
+++ b/src/runtime/fetch.ts
@@ -51,7 +51,7 @@ export function openFetchRequestInterceptor(ctx: FetchContext) {
 
 export function createOpenFetch<Paths>(options: FetchOptions | ((options: FetchOptions) => FetchOptions)): OpenFetchClient<Paths> {
   return (url: string, opts: any) => globalThis.$fetch(
-    fillPath(url, opts.path),
+    fillPath(url, opts?.path),
     typeof options === 'function'
       ? options(opts)
       : {


### PR DESCRIPTION
fix #35

Hi :wave: this PR adds an optional operator to `opts` in case it is undefined