### PR TITLE
fix: use TS file for openAPI TS files

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -113,12 +113,13 @@ export default defineNuxtModule<ModuleOptions>({
     ]
 
     schemas.forEach(({ name, schema, openAPITS }) => {
-      addTypeTemplate({
-        filename: `types/${moduleName}/schemas/${kebabCase(name)}.d.ts`,
+      addTemplate({
+        filename: `types/${moduleName}/schemas/${kebabCase(name)}.ts`,
         getContents: async () => {
           const ast = await openapiTS(schema, openAPITS)
           return astToString(ast)
         },
+        write: true,
       })
     })
 
@@ -161,7 +162,7 @@ export default defineNuxtModule<ModuleOptions>({
         return `
 import { createUseOpenFetch } from '#imports'
 ${schemas.map(({ name }) => `
-import type { paths as ${pascalCase(name)}Paths } from '#build/types/${moduleName}/schemas/${kebabCase(name)}.d.ts'
+import type { paths as ${pascalCase(name)}Paths } from '#build/types/${moduleName}/schemas/${kebabCase(name)}'
 `.trimStart()).join('').trimEnd()}
 
 ${schemas.length ? `export type OpenFetchClientName = ${schemas.map(({ name }) => `'${name}'`).join(' | ')}` : ''}
@@ -192,7 +193,7 @@ export const ${fetchName.lazyComposable} = createUseOpenFetch<${pascalCase(name)
       getContents: () => `
 import type { OpenFetchClient } from '#imports'
 ${schemas.map(({ name }) => `
-import type { paths as ${pascalCase(name)}Paths } from '#build/types/${moduleName}/schemas/${kebabCase(name)}.d.ts'
+import type { paths as ${pascalCase(name)}Paths } from '#build/types/${moduleName}/schemas/${kebabCase(name)}'
 `.trimStart()).join('').trimEnd()}
 
 declare module '#app' {
@@ -217,7 +218,7 @@ export {}
       getContents: () => `
 import type { OpenFetchClient } from '#imports'
 ${schemas.map(({ name }) => `
-import type { paths as ${pascalCase(name)}Paths } from '#build/types/${moduleName}/schemas/${kebabCase(name)}.d.ts'
+import type { paths as ${pascalCase(name)}Paths } from '#build/types/${moduleName}/schemas/${kebabCase(name)}'
 `.trimStart()).join('').trimEnd()}
 
 declare module 'nitropack' {


### PR DESCRIPTION
Hey :wave:

This PR moves generated files from openAPI TS to regular TS files because they don't augment anything and we can't import enums when enabling `enum` option in openAPI TS