### PR TITLE
fix: use alias for schemas

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -103,7 +103,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     nuxt.options.alias = {
       ...nuxt.options.alias,
-      '#nuxt-open-fetch-schemas': join(nuxt.options.buildDir, 'types', moduleName, 'schemas'),
+      '#open-fetch-schemas': join(nuxt.options.buildDir, 'types', moduleName, 'schemas'),
     }
 
     nuxt.options.optimization = nuxt.options.optimization || {
@@ -223,7 +223,7 @@ export {}
       getContents: () => `
 import type { OpenFetchClient } from '#imports'
 ${schemas.map(({ name }) => `
-import type { paths as ${pascalCase(name)}Paths } from '#nuxt-open-fetch-schemas/${kebabCase(name)}'
+import type { paths as ${pascalCase(name)}Paths } from '#open-fetch-schemas/${kebabCase(name)}'
 `.trimStart()).join('').trimEnd()}
 
 declare module 'nitropack' {

--- a/src/module.ts
+++ b/src/module.ts
@@ -15,6 +15,7 @@ import {
 import openapiTS, { astToString } from 'openapi-typescript'
 import { camelCase, kebabCase, pascalCase } from 'scule'
 import { defu } from 'defu'
+import { join } from 'pathe'
 
 type OpenAPI3Schema = string | URL | OpenAPI3 | Readable
 
@@ -98,6 +99,11 @@ export default defineNuxtModule<ModuleOptions>({
           openAPITS: options?.openAPITS,
         })
       }
+    }
+
+    nuxt.options.alias = {
+      ...nuxt.options.alias,
+      '#nuxt-open-fetch-schemas': join(nuxt.options.buildDir, 'types', moduleName, 'schemas'),
     }
 
     nuxt.options.optimization = nuxt.options.optimization || {
@@ -217,7 +223,7 @@ export {}
       getContents: () => `
 import type { OpenFetchClient } from '#imports'
 ${schemas.map(({ name }) => `
-import type { paths as ${pascalCase(name)}Paths } from '#build/types/${moduleName}/schemas/${kebabCase(name)}.d.ts'
+import type { paths as ${pascalCase(name)}Paths } from '#nuxt-open-fetch-schemas/${kebabCase(name)}'
 `.trimStart()).join('').trimEnd()}
 
 declare module 'nitropack' {


### PR DESCRIPTION
Hi :wave:

This adds an alias for generated schemas. There's two reasons:

- we can't use `#build` alias in nitro types
- it can be a DX improvement so users don't have to import from a long path

Would be nice to have a single alias for everything or to add auto-import maybe ?