### PR TITLE
fix: reactive query params

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, useNuxtApp, usePets, useState } from '#imports'
+import { ref, useNuxtApp, usePets } from '#imports'
 
 const { $pets } = useNuxtApp()
 
@@ -18,28 +18,15 @@ await $pets('/store/order', {
   },
 })
 
-const statusAsRef = useState<'available' | 'pending' | 'sold' | undefined>(() => undefined)
-
-const { data, execute } = await usePets('/pet/findByStatus', {
+const { data, execute } = await usePets('/pet/{petId}', {
   immediate: false,
-  query: {
-    status: statusAsRef,
+  path: {
+    petId,
   },
 })
 </script>
 
 <template>
-  <select v-model="statusAsRef" placeholder="Select a status">
-    <option value="available">
-      available
-    </option>
-    <option value="pending">
-      pending
-    </option>
-    <option value="sold">
-      sold
-    </option>
-  </select>
   <pre>{{ data }}</pre>
   <button @click="() => execute()">
     execute

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, useNuxtApp, usePets } from '#imports'
+import { ref, useNuxtApp, usePets, useState } from '#imports'
 
 const { $pets } = useNuxtApp()
 
@@ -18,15 +18,28 @@ await $pets('/store/order', {
   },
 })
 
-const { data, execute } = await usePets('/pet/{petId}', {
+const statusAsRef = useState<'available' | 'pending' | 'sold' | undefined>(() => undefined)
+
+const { data, execute } = await usePets('/pet/findByStatus', {
   immediate: false,
-  path: {
-    petId,
+  query: {
+    status: statusAsRef,
   },
 })
 </script>
 
 <template>
+  <select v-model="statusAsRef" placeholder="Select a status">
+    <option value="available">
+      available
+    </option>
+    <option value="pending">
+      pending
+    </option>
+    <option value="sold">
+      sold
+    </option>
+  </select>
   <pre>{{ data }}</pre>
   <button @click="() => execute()">
     execute

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -18,7 +18,7 @@ await $pets('/store/order', {
   },
 })
 
-const status = useState<'available' | undefined>(() => undefined)
+const status = useState<'available' | 'pending' | 'sold' | undefined>(() => undefined)
 const { data, execute } = await usePets('/pet/findByStatus', {
   immediate: false,
   query: {

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, useNuxtApp, usePets } from '#imports'
+import { ref, useNuxtApp, usePets, useState } from '#imports'
 
 const { $pets } = useNuxtApp()
 
@@ -18,15 +18,27 @@ await $pets('/store/order', {
   },
 })
 
-const { data, execute } = await usePets('/pet/{petId}', {
+const status = useState<'available' | undefined>(() => undefined)
+const { data, execute } = await usePets('/pet/findByStatus', {
   immediate: false,
-  path: {
-    petId,
+  query: {
+    status,
   },
 })
 </script>
 
 <template>
+  <select v-model="status" placeholder="Select a status">
+    <option value="available">
+      available
+    </option>
+    <option value="pending">
+      pending
+    </option>
+    <option value="sold">
+      sold
+    </option>
+  </select>
   <pre>{{ data }}</pre>
   <button @click="() => execute()">
     execute

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -18,17 +18,18 @@ await $pets('/store/order', {
   },
 })
 
-const status = useState<'available' | 'pending' | 'sold' | undefined>(() => undefined)
+const statusAsRef = useState<'available' | 'pending' | 'sold' | undefined>(() => undefined)
+
 const { data, execute } = await usePets('/pet/findByStatus', {
   immediate: false,
   query: {
-    status,
+    status: statusAsRef,
   },
 })
 </script>
 
 <template>
-  <select v-model="status" placeholder="Select a status">
+  <select v-model="statusAsRef" placeholder="Select a status">
     <option value="available">
       available
     </option>

--- a/src/runtime/useFetch.ts
+++ b/src/runtime/useFetch.ts
@@ -9,8 +9,11 @@ import type { OpenFetchClientName } from '#build/open-fetch'
 type PickFrom<T, K extends Array<string>> = T extends Array<any> ? T : T extends Record<string, any> ? keyof T extends K[number] ? T : K[number] extends never ? T : Pick<T, K[number]> : T
 type KeysOf<T> = Array<T extends T ? keyof T extends string ? keyof T : never : never>
 
+type ReactiveQueryParam<P> = {
+  [K in keyof P]: Ref<P[K]> | P[K]
+}
 type ComputedOptions<T> = {
-  [K in keyof T]: T[K] extends Function ? T[K] : T[K] extends Record<string, unknown> ? ComputedOptions<T[K]> : Ref<T[K]> | T[K]
+  [K in keyof T]: T[K] extends Function ? T[K] : T[K] extends Record<string, unknown> ? ComputedOptions<T[K]> : K extends 'query' ? Ref<ReactiveQueryParam<T[K]>> | ReactiveQueryParam<T[K]> : Ref<T[K]> | T[K]
 }
 type ComputedMethodOption<M, P> = 'get' extends keyof P ? ComputedOptions<{ method?: M }> : ComputedOptions<{ method: M }>
 

--- a/src/runtime/useFetch.ts
+++ b/src/runtime/useFetch.ts
@@ -9,11 +9,11 @@ import type { OpenFetchClientName } from '#build/open-fetch'
 type PickFrom<T, K extends Array<string>> = T extends Array<any> ? T : T extends Record<string, any> ? keyof T extends K[number] ? T : K[number] extends never ? T : Pick<T, K[number]> : T
 type KeysOf<T> = Array<T extends T ? keyof T extends string ? keyof T : never : never>
 
-type ReactiveQueryParam<P> = {
-  [K in keyof P]: Ref<P[K]> | P[K]
+type QueryParams<P> = {
+  [K in keyof P]: P[K] | Ref<P[K]>
 }
 type ComputedOptions<T> = {
-  [K in keyof T]: T[K] extends Function ? T[K] : T[K] extends Record<string, unknown> ? ComputedOptions<T[K]> : K extends 'query' ? Ref<ReactiveQueryParam<T[K]>> | ReactiveQueryParam<T[K]> : Ref<T[K]> | T[K]
+  [K in keyof T]: T[K] extends Function ? T[K] : T[K] extends Record<string, unknown> ? ComputedOptions<T[K]> : K extends 'query' ? Ref<QueryParams<T[K]>> | QueryParams<T[K]> : Ref<T[K]> | T[K]
 }
 type ComputedMethodOption<M, P> = 'get' extends keyof P ? ComputedOptions<{ method?: M }> : ComputedOptions<{ method: M }>
 


### PR DESCRIPTION
Modify the `ComputedOptions` interface to allow for reactive `query` params as explained by #52 .

@enkot this should be tested to ensure I didn't miss something with the new interface (and that it doesn't impact other `parameters` properties).