### PR TITLE
fix: add header parameters to headers

### DIFF
--- a/src/runtime/useFetch.ts
+++ b/src/runtime/useFetch.ts
@@ -64,7 +64,10 @@ export function createUseOpenFetch<
     const nuxtApp = useNuxtApp()
     const $fetch = (typeof client === 'string' ? nuxtApp[`$${client}`] : client)
     const opts = { $fetch, key: autoKey, ...options }
-
+    if (opts.header) {
+      opts.headers = opts.header
+      delete opts.header
+    }
     return useFetch(() => toValue(url), lazy ? { ...opts, lazy } : opts)
   }
 }


### PR DESCRIPTION
this fix [79](https://github.com/enkot/nuxt-open-fetch/issues/79)

Openapi request a `header` key ( `"in":"header"` ) while fetch `headers`. 

