### PR TITLE
fix: type helpers

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -188,7 +188,7 @@ export const ${fetchName.composable} = createUseOpenFetch<${pascalCase(name)}Pat
  */
 export const ${fetchName.lazyComposable} = createUseOpenFetch<${pascalCase(name)}Paths>('${name}', true)
 
-export type ${pascalCase(name)}Response<T extends keyof ${pascalCase(name)}Operations, R extends keyof ${pascalCase(name)}Operations[T]['responses'] = 200 extends keyof ${pascalCase(name)}Operations[T]['responses'] ? 200 : never> = ${pascalCase(name)}Operations[T]['responses'][R] extends { content: { 'application/json': infer U } }
+export type ${pascalCase(name)}Response<T extends keyof ${pascalCase(name)}Operations, R extends keyof ${pascalCase(name)}Operations[T]['responses'] & number = Extract<keyof ${pascalCase(name)}Operations[T]['responses'] & number, 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207 | 208 | 226>> = ${pascalCase(name)}Operations[T]['responses'][R] extends { content: { 'application/json': infer U } }
   ? U
   : never
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -192,7 +192,7 @@ export type ${pascalCase(name)}Response<T extends keyof ${pascalCase(name)}Opera
   ? U
   : never
 
-export type ${pascalCase(name)}RequestBody<T extends keyof ${pascalCase(name)}Operations> = ${pascalCase(name)}Operations[T]['requestBody'] extends { content: { 'application/json': infer U } }
+export type ${pascalCase(name)}RequestBody<T extends keyof ${pascalCase(name)}Operations> = ${pascalCase(name)}Operations[T] extends { requestBody?: { content: { 'application/json': infer U } } | undefined }
   ? U
   : never
 


### PR DESCRIPTION
## Response type helper

Update the generated client `Response` interface to include all valid `2xx` response codes. Resolves #88.

## RequestBody type helper

Also updates the client `RequestBody` interface to handle required _and optional_ `requestBody`


```typescript
// An operation with optional request body
type Operation1 = {
  requestBody?: { content: { 'application/json': { name: string } } }
}

// An operation with required request body
type Operation2 = {
  requestBody: { content: { 'application/json': { id: number } } }
}

// Original version:
type Test1 = Operation1['requestBody'] extends { content: { 'application/json': infer U } } ? U : never
// Result: never (fails)

// Updated version:
type Test2 = Operation1 extends { requestBody?: { content: { 'application/json': infer U } } } ? U : never
// Result: { name: string } (works)
```

The updated version works for both required and optional request bodies