### PR TITLE
refactor: replace deprecated toMatchTypeOf

### DIFF
--- a/playground/tests/types.spec.ts
+++ b/playground/tests/types.spec.ts
@@ -71,7 +71,7 @@ describe('$[client]', async () => {
 
   it('has correct return type', () => async () => {
     const data = await $pets('/pet/{petId}')
-    expectTypeOf(data).toMatchTypeOf<ReturnData>()
+    expectTypeOf(data).toExtend<ReturnData>()
   })
 
   it('returns correct type based on accept header', () => async () => {
@@ -139,7 +139,7 @@ describe('use[Client]', async () => {
       immediate: false,
     })
 
-    expectTypeOf(data).toMatchTypeOf<Ref<ReturnData | undefined>>()
+    expectTypeOf(data).toExtend<Ref<ReturnData | undefined>>()
   })
 
   it('has correct "transform" input parameter type', () => () => {
@@ -162,9 +162,7 @@ describe('use[Client]', async () => {
       immediate: false,
     })
 
-    expectTypeOf(data).toMatchTypeOf<Ref<{
-      foo: string
-    } | undefined>>()
+    expectTypeOf(data).toExtend<Ref<{ foo: string } | undefined>>()
   })
 
   it('has correct reponse type using "default"', () => () => {
@@ -176,9 +174,7 @@ describe('use[Client]', async () => {
       immediate: false,
     })
 
-    expectTypeOf(data).toMatchTypeOf<Ref<ReturnData | {
-      bar: number
-    }>>()
+    expectTypeOf(data).toExtend<Ref<ReturnData | { bar: number }>>()
   })
 
   it('has correct response type using "default" and "transform"', () => () => {
@@ -193,11 +189,7 @@ describe('use[Client]', async () => {
       immediate: false,
     })
 
-    expectTypeOf(data).toMatchTypeOf<Ref<{
-      foo: string
-    } | {
-      bar: number
-    }>>()
+    expectTypeOf(data).toExtend<Ref<{ foo: string } | { bar: number }>>()
   })
 
   it('has correct response type using "pick"', () => () => {
@@ -207,9 +199,7 @@ describe('use[Client]', async () => {
       immediate: false,
     })
 
-    expectTypeOf(data).toMatchTypeOf<Ref<{
-      name: string
-    } | undefined>>()
+    expectTypeOf(data).toExtend<Ref<{ name: string } | undefined>>()
   })
 
   it('returns correct type based on accept header', () => () => {


### PR DESCRIPTION
While checking out the tests I stumbled over the deprecation warning for `toMatchTypeOf`. The docs don't say anything about that so I dug a bit deeper and found out that the method was deprecated quite a while ago in [v1.2.0](https://github.com/mmkal/expect-type/releases/tag/v1.2.0).

The docs have only been updated recently: https://github.com/vitest-dev/vitest/issues/8387, but that change has not been released yet and can only be seen in the docs for v4: https://main.vitest.dev/api/expect-typeof.html#tomatchtypeof.

I also tried if I can replace any of the usages with [`toMatchObjectType`](https://main.vitest.dev/api/expect-typeof.html#tomatchobjecttype), but that gave me the error that it only works on object types. I'm guessing that the type of `data` might be too complex for that.