### PR TITLE
fix(module): avoid #imports in generated usefetch client

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -115,6 +115,7 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.alias = {
       ...nuxt.options.alias,
       '#open-fetch': join(nuxt.options.buildDir, moduleName),
+      '#open-fetch-use-fetch': resolve('runtime/useFetch'),
       '#open-fetch-schemas/*': join(nuxt.options.buildDir, 'types', moduleName, 'schemas', '*'),
     }
 
@@ -218,7 +219,7 @@ export {}
       filename: `${moduleName}.ts`,
       getContents() {
         return `
-import { createUseOpenFetch } from '#imports'
+import { createUseOpenFetch } from '#open-fetch-use-fetch'
 ${schemas.map(({ name }) => `
 import type { paths as ${pascalCase(name)}Paths, operations as ${pascalCase(name)}Operations } from '#open-fetch-schemas/${kebabCase(name)}'
 `.trimStart()).join('').trimEnd()}


### PR DESCRIPTION
closes #132.

The generated `.nuxt/open-fetch.ts` currently imports `createUseOpenFetch` from `#imports`, which can fail during consumer `nuxi typecheck` even though the symbol is registered as an auto-import.

This keeps the change narrow by:
- adding a dedicated internal alias for `runtime/useFetch`
- using that alias in the generated `open-fetch.ts` template instead of `#imports`