### PR TITLE
fix(runtime): support Nitro 3 imports

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -13,6 +13,7 @@ import {
   addTypeTemplate,
   createResolver,
   defineNuxtModule,
+  getNuxtVersion,
 } from '@nuxt/kit'
 import { hash } from 'ohash'
 import openapiTS, { astToString } from 'openapi-typescript'
@@ -122,6 +123,12 @@ export default defineNuxtModule<ModuleOptions>({
       '#open-fetch': join(nuxt.options.buildDir, moduleName),
       '#open-fetch-use-fetch': resolve('runtime/useFetch'),
       '#open-fetch-schemas/*': join(nuxt.options.buildDir, 'types', moduleName, 'schemas', '*'),
+    }
+    nuxt.options.nitro.alias = {
+      ...nuxt.options.nitro.alias,
+      '#open-fetch-nitro-runtime-config': Number.parseInt(getNuxtVersion(nuxt), 10) >= 5
+        ? 'nitro/runtime-config'
+        : 'nitropack/runtime',
     }
 
     nuxt.options.optimization = nuxt.options.optimization || {

--- a/src/runtime/nitro-plugin.ts
+++ b/src/runtime/nitro-plugin.ts
@@ -1,9 +1,9 @@
 // @ts-ignore
-import { defineNitroPlugin, useRuntimeConfig } from '#imports'
+import { useRuntimeConfig } from '#open-fetch-nitro-runtime-config'
 import { createOpenFetch } from './fetch'
 
 // @ts-ignore
-export default defineNitroPlugin((nitroApp) => {
+export default (nitroApp) => {
   const clients = useRuntimeConfig().public.openFetch
 
   // @ts-ignore
@@ -11,4 +11,4 @@ export default defineNitroPlugin((nitroApp) => {
     // @ts-ignore
     nitroApp[`$${name}`] = createOpenFetch(client, nitroApp.localFetch, name, nitroApp.hooks)
   })
-})
+}


### PR DESCRIPTION
The Nitro runtime plugin currently imports from `#imports`, which is unavailable in Nitro 3. Importing directly from Nitro 3 would break the module's supported Nuxt 3/4 line.

This keeps one plugin implementation and resolves only the runtime-config provider during module setup:

- `nitropack/runtime` for Nuxt 3/4
- `nitro/runtime-config` for Nuxt 5 and later

The plugin exports the handler directly because both Nitro generations wrap plugins as identity functions.

Validated with the packed module on Nuxt 4.4.8/Nitro 2.13.4 and Nuxt 5 nightly/Nitro 3, including runtime routes that confirm the configured Open Fetch client is installed. The upstream lint, typecheck, and 30 tests also pass.