### PR TITLE
fix(runtime): fall back to ofetch when global fetch is unavailable

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "@nuxt/kit": "^4.5.1",
     "defu": "^6.1.5",
+    "ofetch": "^1.5.1",
     "ohash": "^2.0.11",
     "openapi-typescript": "^7.13.0",
     "openapi-typescript-helpers": "^0.1.0",
@@ -77,8 +78,7 @@
     "eslint": "^9.39.1",
     "happy-dom": "^20.10.6",
     "listhen": "^1.9.0",
-    "nuxt": "^4.5.1",
-    "ofetch": "^1.5.1"
+    "nuxt": "^4.5.1"
   },
   "resolutions": {
     "@norbiros/nuxt-open-fetch": "workspace:*"

--- a/playground/tests/runtime/fetch-fallback.spec.ts
+++ b/playground/tests/runtime/fetch-fallback.spec.ts
@@ -1,0 +1,23 @@
+import { $fetch as ofetch } from 'ofetch'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createOpenFetch } from '../../../src/runtime/fetch'
+
+vi.mock('ofetch', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('ofetch')>()
+  return { ...actual, $fetch: vi.fn() }
+})
+
+describe('fetch fallback', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('uses ofetch when globalThis.$fetch is unavailable', async () => {
+    const fetchSpy = vi.mocked(ofetch).mockResolvedValue({ id: 1 } as any)
+    vi.stubGlobal('$fetch', undefined)
+
+    await expect(createOpenFetch<any>({})('https://example.com')).resolves.toEqual({ id: 1 })
+    expect(fetchSpy).toHaveBeenCalledWith('https://example.com', expect.any(Object))
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       defu:
         specifier: ^6.1.5
         version: 6.1.7
+      ofetch:
+        specifier: ^1.5.1
+        version: 1.5.1
       ohash:
         specifier: ^2.0.11
         version: 2.0.11
@@ -63,9 +66,6 @@ importers:
       nuxt:
         specifier: ^4.5.1
         version: 4.5.1(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(@types/node@24.10.1)(@vue/compiler-sfc@3.5.40)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.6.2))(esbuild@0.28.1)(eslint@9.39.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.140.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.53.3))(rollup@4.53.3)(srvx@0.12.4)(terser@5.44.1)(typescript@5.9.3)(vite@8.1.5(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(yaml@2.9.0))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.9.0)
-      ofetch:
-        specifier: ^1.5.1
-        version: 1.5.1
 
   docs:
     dependencies:

--- a/src/runtime/fetch.ts
+++ b/src/runtime/fetch.ts
@@ -10,6 +10,7 @@ import type {
   ResponseObjectMap,
   SuccessResponse,
 } from 'openapi-typescript-helpers'
+import { $fetch as ofetch } from 'ofetch'
 
 interface OpenFetchHooks {
   callHook: (name: any, ...args: any[]) => any
@@ -186,7 +187,7 @@ function getFetch(url: string, opts: FetchOptions, localFetch?: typeof globalThi
       return localFetch
   }
 
-  return globalThis.$fetch
+  return globalThis.$fetch || ofetch
 }
 
 export function fillPath(path: string, params: Record<string, string> = {}) {


### PR DESCRIPTION
## What changed

Open Fetch now uses the direct ofetch implementation when `globalThis.$fetch` is unavailable. Nitro local fetch handling remains unchanged for relative server-side requests, and ofetch is declared as a runtime dependency because the generated package imports it directly.

## Why

Nuxt 5 and Nitro 3 execution can reach this runtime from a Nitro server route before Nuxt's app-entry fetch setup has seeded `globalThis.$fetch`. The previous fallback returned `undefined`, so the generated client failed when it tried to invoke the selected fetch function.

The framework boundary was checked against current Nuxt and Nitro sources. Nitro provides native `fetch`/`serverFetch`; Nuxt seeds the global `$fetch` through its generated app-entry setup. This PR keeps the compatibility fix in Open Fetch, where the runtime currently assumes that global.

## Validation

- Module build succeeds and generated `dist/runtime/fetch.js` contains the ofetch import and fallback.
- A Nitro-style runtime probe passes with `globalThis.$fetch` absent and a local HTTP server.
- The focused regression test stubs `globalThis.$fetch` and verifies the direct ofetch path is selected.
- The prior PR checks passed: lint, module/playground build, 5 files with 12 tests, root and playground vue-tsc, and `git diff --check`.
